### PR TITLE
support SlugId Options for next (vue 3.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,8 @@ Since Vue 3 is not backward compatible, please make sure to install the correct 
 
 | Vue Version | Package Version |
 |-------------|-----------------|
-| 2.x         | 1.x             |
-| 3.x         | 2.x             |
-
+| 2.x         | 3.x             |
+| 3.x         | 4.x             |
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -134,10 +134,11 @@ You have to pass `options` object to `ByteArkPlayerContainer`
 | volume       | Number       | -       | Video's volume between 0 and 1.                                              |
 | plugins      | Array        | -       | Videojs's plugins                                                            |
 
-The following 4 properties can also be added to `options` for an advanced usage.
+The following 5 properties can also be added to `options` for an advanced usage.
 
 | Name                      | Type     | Description                                                                     |
 |---------------------------|----------|---------------------------------------------------------------------------------|
+| playerSlugId              | String   | SlugId of player created via api player server service                          |
 | playerVersion             | String   | Custom version of the player. (default: 'v1')                                   |
 | playerEndpoint            | String   | Endpoint to the video player (without version part and ending slash).           |
 | playerJsFileName          | String   | File name of player's JS. (default: 'byteark-player.min.js')                    |

--- a/src/components/ByteArkPlayerContainer.vue
+++ b/src/components/ByteArkPlayerContainer.vue
@@ -88,7 +88,9 @@ export default {
         fluid: true,
         playsInLine: true,
         poster: '',
+        playerSlugId: '',
         sources: {},
+        playerServerEndpoint: 'https://player.byteark.com/players',
         playerEndpoint: 'https://byteark-sdk.cdn.byteark.com/player-core',
         playerVersion: 'v2',
         playerJsFileName: 'byteark-player.min.js',
@@ -299,20 +301,37 @@ export default {
     async loadPlayerResources() {
       try {
         const promises = [];
-        promises.push(
-          loadScriptOrStyle(
-            `byteark-player-script-${this.defaultOptions.playerVersion}`,
-            `${this.defaultOptions.playerEndpoint}/${this.defaultOptions.playerVersion}/${this.defaultOptions.playerJsFileName}`,
-            'script',
-          ),
-        );
-        promises.push(
-          loadScriptOrStyle(
-            `byteark-player-style-${this.defaultOptions.playerVersion}`,
-            `${this.defaultOptions.playerEndpoint}/${this.defaultOptions.playerVersion}/${this.defaultOptions.playerCssFileName}`,
-            'style',
-          ),
-        );
+        if (this.defaultOptions.playerSlugId) {
+          promises.push(
+            loadScriptOrStyle(
+              `byteark-player-script-${this.defaultOptions.playerSlugId}`,
+              `${this.defaultOptions.playerServerEndpoint}/${this.defaultOptions.playerSlugId}/libraries/${this.defaultOptions.playerJsFileName}`,
+              'script',
+            ),
+          );
+          promises.push(
+            loadScriptOrStyle(
+              `byteark-player-style-${this.defaultOptions.playerSlugId}`,
+              `${this.defaultOptions.playerServerEndpoint}/${this.defaultOptions.playerSlugId}/libraries/${this.defaultOptions.playerCssFileName}`,
+              'style',
+            ),
+          );
+        } else {
+          promises.push(
+            loadScriptOrStyle(
+              `byteark-player-script-${this.defaultOptions.playerVersion}`,
+              `${this.defaultOptions.playerEndpoint}/${this.defaultOptions.playerVersion}/${this.defaultOptions.playerJsFileName}`,
+              'script',
+            ),
+          );
+          promises.push(
+            loadScriptOrStyle(
+              `byteark-player-style-${this.defaultOptions.playerVersion}`,
+              `${this.defaultOptions.playerEndpoint}/${this.defaultOptions.playerVersion}/${this.defaultOptions.playerCssFileName}`,
+              'style',
+            ),
+          );
+        }
         await Promise.all(promises);
       } catch (originalError) {
         this.defaultOnPlayerLoadingError(originalError);


### PR DESCRIPTION
- add `playerSlugId` and `playerServerEndpoint` fields to ByteArkPlayerContainer's `defaultOptions`
- add `playerSlugId` fields in advanced usage section in `README.md`